### PR TITLE
Allow find/replace to run on entire obsidian note, not just post content

### DIFF
--- a/obyde/__init__.py
+++ b/obyde/__init__.py
@@ -201,9 +201,13 @@ def process_vault(config):
     for slug_name, data in dated_files.items():
         _, dated_name_ext, path = data
         post = post_map[slug_name]
-        rewritten = find_replace(post.content, post.metadata)
+
+        # Allow find_replace to run on metadata in addition to post content
+        post_text = find_replace(frontmatter.dumps(post), post.metadata)
+        post = frontmatter.loads(post_text)
+
         rewritten = rewrite_links(
-            rewritten, dated_files, copied_asset_files, relative_asset_path_prefix, post_link_mode)
+            post.content, dated_files, copied_asset_files, relative_asset_path_prefix, post_link_mode)
         post.content = rewritten
         with open(os.path.join(post_output_path, dated_name_ext),  'wb') as out:
             frontmatter.dump(post, out)


### PR DESCRIPTION
Open to feedback if this is currently working as intended. Previously, I was using find-replace to also modify the metadata of a note before posting it. For example, removing personal metadata or assigning tags at publish-time so they don't clutter up my vault. A previous PR changed find-replace to only apply to the post content, which broke that workflow for me. This returns to the practice of running find-replace on the entire markdown file before creating the post. Let me know if you feel this will cause more issues than its worth.